### PR TITLE
patch: add preload link in document head and enabling source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Card Web Components for the uPortal ecosystem",
   "main": "dist/index.js",
   "scripts": {
-    "css-build": "node-sass --omit-source-map-url static/scss/my-card.scss static/css/my-card.css --output-style compressed",
+    "css-build": "node-sass static/scss/my-card.scss static/css/my-card.css --output-style compressed",
     "css-watch": "npm run css-build -- --watch",
     "prebuild": "rm -rf dist | npm run css-build",
     "build": "rollup -c",

--- a/src/my-card.js
+++ b/src/my-card.js
@@ -133,16 +133,16 @@ class myCard extends HTMLElement {
     /**
      * build the import style tag into the Shadow DOM and append it to the ShadowDOM
      */
+    var head = document.head || document.getElementsByTagName("head")[0];
     var preloadLink = document.createElement("link");
     let temphrefcss = `${baseCss}` + "/my-card.css";
     preloadLink.href = temphrefcss.toString();
     preloadLink.rel = "preload";
     preloadLink.as = "style";
-    preloadLink.toString();
+    head.appendChild(preloadLink);
     const stylesImportTag = document.createElement("style");
     stylesImportTag.lang = "css";
     stylesImportTag.innerHTML = "@import '" + `${baseCss}` + "/my-card.css';";
-    stylesImportTag.toString();
     root`
 
 
@@ -222,9 +222,7 @@ class myCard extends HTMLElement {
     </div>
   </div>
 
-`
-      .appendChild(preloadLink)
-      .appendChild(stylesImportTag);
+`.appendChild(stylesImportTag);
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the Project Github issue tracker

-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Resolve issue/feat. n° <!-- add #theNumberInGithubIssue -->
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] existing message properties have been updated with new phrases
- [ ] new (i18n) language set have been added
- [ ] improvement to make view conforms with [WCAG 2.1 AA][]

##### Description of change
patch put preload link in document head && enable source maps
there were a warning in console:

```
my-card.umd.js:2217 HTML element <link> is ignored in shadow tree.
render @ my-card.umd.js:2217
```

<!-- Reference Links -->

[wcag 2.1 aa]: https://www.w3.org/TR/WCAG21/
