### PR TITLE
i18n: Add support for Standart Arabic

### DIFF
--- a/src/my-card.js
+++ b/src/my-card.js
@@ -72,6 +72,7 @@ class myCard extends HTMLElement {
    */
   urlMessages(path, pageLang) {
     switch (pageLang) {
+      case "ar":
       case "fr-FR":
       case "es-ES":
       case "en-US":
@@ -143,12 +144,15 @@ class myCard extends HTMLElement {
     const stylesImportTag = document.createElement("style");
     stylesImportTag.lang = "css";
     stylesImportTag.innerHTML = "@import '" + `${baseCss}` + "/my-card.css';";
+    var classlang =
+      "card-wrapper" + " " + document.getElementsByTagName("html")[0].lang;
+
     root`
 
 
 
 
-  <div data-magic="${data.magic}" class="card-wrapper">
+  <div data-magic="${data.magic}" class="${classlang}">
     <div class="card radius shadowDepth1">
       <div class="card__image border-tlr-radius">
         <!--<img src="csm_hellink_268d15ec81 - Copie.jpg" alt="image" class="border-tlr-radius" />-->
@@ -161,9 +165,9 @@ class myCard extends HTMLElement {
           <div class="card__meta">
           <img src="${baseSvg +
             "solid/tags.svg"}" class="icon-black" alt="Tags" lang="en-US">&nbsp;:
-          <span>${data.List.map(
+          <div>${data.List.map(
             l => ` <a href="javascript:void(0);">${l.tag}</a> -`
-          )}</span>&nbsp;
+          )}</div>&nbsp;
           <time>${data.time}</time>
           </div>
           <div id="what-is-uportal-i18n-list" class="card__share" tabindex="-1" role="menu">

--- a/static/css/my-card.css
+++ b/static/css/my-card.css
@@ -104,6 +104,89 @@ a:focus-visible {
 .shadowDepth1 {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
+.rtl {
+  direction: rtl;
+}
+div.ar div.card__content div.card__article h2 {
+  font-size: 135% !important;
+  direction: rtl !important;
+  float: left !important;
+}
+div.ar div.card__content div.card__article div.card__meta {
+  clear: left !important;
+  top: -0.4rem !important;
+  padding: 0 4.3rem 0 1.6rem !important;
+  position: relative;
+  direction: rtl !important;
+}
+div.ar div.card__content div.card__article div.card__meta time {
+  direction: rtl !important;
+}
+div.ar div.card__content div.card__article div.text {
+  direction: rtl !important;
+}
+div.ar div.card__content div.card__article div.text p {
+  margin-bottom: 1rem;
+  text-align: justify;
+}
+div.ar div.card__content div.card__article div.text p:first-of-type:first-line {
+  font-variant-caps: small-caps;
+}
+div.ar
+  div.card__content
+  div.card__article
+  div.text
+  p:first-of-type::first-line {
+  font-variant-caps: small-caps;
+}
+div.ar
+  div.card__content
+  div.card__article
+  div.text
+  p:first-of-type:first-letter {
+  float: none !important;
+  padding-right: 0 !important;
+  font-family: Georgia, "New Times Roman", serif;
+  font-size: initial !important;
+  font-variant-caps: normal !important;
+  line-height: initial !important;
+  margin-bottom: 0 !important;
+  color: initial !important;
+}
+div.ar
+  div.card__content
+  div.card__article
+  div.text
+  p:first-of-type::first-letter {
+  float: none !important;
+  padding-right: 0 !important;
+  font-family: Georgia, "New Times Roman", serif;
+  font-size: initial !important;
+  font-variant-caps: normal !important;
+  line-height: initial !important;
+  margin-bottom: 0 !important;
+  color: initial !important;
+}
+div.ar div.card__content div.card__article div.text p:last-child:after {
+  color: #777;
+  content: "\2766";
+  display: inline;
+  font-family: Georgia, "New Times Roman", serif;
+  font-size: 1.25em;
+  font-style: italic;
+  font-weight: 300;
+  line-height: 0.75;
+}
+div.ar div.card__action a.btn-default {
+  border: 1px solid black;
+  background-color: white;
+  color: black !important;
+}
+div.ar div.card__action a.btn-danger {
+  border: 1px solid red;
+  background-color: #e90000;
+  color: white;
+}
 div.card-wrapper img[src$=".svg"] {
   width: 21px;
   height: 21px;
@@ -180,7 +263,15 @@ div.card-wrapper
   div.card__content
   div.card__article
   div.card__meta
-  span
+  div {
+  display: inline-block;
+}
+div.card-wrapper
+  div.card
+  div.card__content
+  div.card__article
+  div.card__meta
+  div
   a {
   color: #005aa9;
   text-decoration: none;
@@ -191,14 +282,14 @@ div.card-wrapper
   div.card__content
   div.card__article
   div.card__meta
-  span
+  div
   a:hover,
 div.card-wrapper
   div.card
   div.card__content
   div.card__article
   div.card__meta
-  span
+  div
   a:focus {
   color: #00315d;
   text-decoration: underline;
@@ -208,7 +299,7 @@ div.card-wrapper
   div.card__content
   div.card__article
   div.card__meta
-  span
+  div
   a:focus-visible {
   outline: 3px #00315d dashed;
   padding: 0.3rem;
@@ -621,7 +712,7 @@ div.card-wrapper
   div.card__content
   div.card__article
   div.text
-  p::first-of-type::first-line {
+  p:first-of-type::first-line {
   font-variant-caps: small-caps;
 }
 div.card-wrapper

--- a/static/i18n/ar/messages.json
+++ b/static/i18n/ar/messages.json
@@ -1,0 +1,61 @@
+{
+  "imgsrc": "https://cousquer.github.io/apereo2017/assets/artworks/apereo-uportal.jpg",
+  "title": "ما هو uPortal؟",
+  "time": "13 يونيو 2018",
+  "linkMenu1": {
+    "id": "museum-menu-item-1",
+    "cssClass": "share-icon lightblue",
+    "glyphicon": "brands/twitter.svg",
+    "iconColor": "icon-white",
+    "label": "Twitter: uPortal",
+    "link": "https://twitter.com/uPortal",
+    "name": "Twitter: uPortal"
+  },
+  "linkMenu2": {
+    "id": "museum-menu-item-2",
+    "cssClass": "share-icon strongblue rtl",
+    "glyphicon": "solid/envelope.svg",
+    "iconColor": "icon-white",
+    "label": "اتصل",
+    "link": "mailto:uportal-user@apereo.org",
+    "name": "اتصل"
+  },
+  "linkMenu3": {
+    "id": "museum-menu-item-3",
+    "cssClass": "share-icon black",
+    "glyphicon": "brands/github.svg",
+    "iconColor": "icon-white",
+    "label": "Github: uPortal",
+    "link": "https://github.com/jasig/uPortal",
+    "name": "Github: uPortal"
+  },
+  "List": [
+    { "tag": "برنامج مفتوح المصدر" },
+    { "tag": "Apereo" },
+    { "tag": "بوابة الويب" }
+  ],
+  "paragraphs": [
+    {
+      "para": "<a href='http://www.apereo.org/uportal' rel='noreferrer noopener' target='_blank'>uPortal</a> عبارة عن منصة بوابة ويب مجانية مفتوحة المصدر ومفتوحة المصدر تم تطويرها وصيانتها من قبل المشاركين من التعليم العالي في إطار تنسيق <a href='http://www.apereo.org/' rel='noreferrer noopener' target='_blank'>Apereo</a>. يمكن لـ uPortal تجميع المحتوى ، وتقديم تطبيقات الخدمة الذاتية ، وتخصيص العرض التقديمي والمحتوى على أساس المجموعات وسمات المستخدم ، ودفع تطبيقات الجهاز المحمول ، والسماح بالتخصيص المتقدم للمستخدم النهائي لتجارب البوابة.تدعم uPortal مواصفات JSR-286 و JSR-168 Java portlet لتضمين تطبيقاتك المخصصة داخل البوابة."
+    },
+    { "para": "مرحبًا بك في uPortal." }
+  ],
+  "button1": {
+    "id": "museum-button-1",
+    "cssClass": "btn btn-default btn-lg rtl",
+    "glyphicon": "brands/github.svg",
+    "iconColor": "icon-black",
+    "label": "اطلب من المصادر على Github",
+    "link": "https://github.com/jasig/uportal-start",
+    "name": "uPortal-Start"
+  },
+  "button2": {
+    "id": "museum-button-2",
+    "cssClass": "btn btn-danger btn-lg rtl",
+    "glyphicon": "solid/book.svg",
+    "iconColor": "icon-white",
+    "label": "الوثائق الإنجليزية",
+    "link": "http://jasig.github.io/uPortal/",
+    "name": "الوثائق الإنجليزية"
+  }
+}

--- a/static/index_ar.html
+++ b/static/index_ar.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+   <head>
+      <meta charset="UTF-8">
+      <title>CardWebComponent for uPortal</title>
+      <meta charset="utf-8"/>
+      <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+      <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+      <meta name="apple-mobile-web-app-capable" content="yes"/>
+      <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
+      <meta name="description" content="POC webcomponents"/>
+      <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.2.0/webcomponents-lite.js" as="script">
+      <link rel="preload" href="https://unpkg.com/regenerator-runtime@0.12.1/runtime.js" as="script">
+      <link rel="preload" href="my-card.umd.js" as="script">
+      <!-- Latest compiled and minified CSS -->
+      
+   </head>
+
+   <body>
+      <my-card id="what-is-uportal-i18n" messagesPath="./" cssPath="css"></my-card>
+
+      <script src='https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.2.0/webcomponents-lite.js' defer></script>
+      <script src='https://unpkg.com/regenerator-runtime@0.12.1/runtime.js' defer></script>
+      <script src="my-card.umd.js" defer></script>
+   </body>
+</html>

--- a/static/scss/my-card.scss
+++ b/static/scss/my-card.scss
@@ -35,6 +35,165 @@ a:focus-visible {
 .shadowDepth1 {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
+.rtl {
+  direction: rtl;
+}
+
+
+
+div.ar {
+
+  div.card {
+
+    div.card__image {
+
+    }
+  }
+
+  div.card__content {
+
+
+    div.card__article {
+
+
+      h2 {
+        font-size: 135%  !important;
+        direction: rtl !important;
+        float: left  !important;
+      }
+
+      div.card__meta {
+        clear: left  !important;
+        top: -0.4rem  !important;
+        padding: 0 4.3rem 0 1.6rem  !important;
+        position: relative;
+        direction: rtl  !important;
+
+        img.icon-black {
+
+        }
+
+        div {
+
+          a {
+
+          }
+        }
+
+        time {
+          direction: rtl  !important;
+
+        }
+      }
+
+      div.card__share {
+
+        div.card__social {
+
+
+          .share-icon {
+
+          }
+
+        }
+
+        div.card__social--active {
+
+        }
+
+        a.share-toggle {
+
+        }
+
+        a:focus-visible {
+
+        }
+      }
+
+      div.share-expanded {
+
+      }
+
+      div.text {
+        direction: rtl  !important;
+        p {
+          margin-bottom: 1rem;
+          text-align: justify;
+
+
+          &:first-of-type:first-line {
+            font-variant-caps: small-caps;
+          }
+
+          &:first-of-type::first-line {
+            font-variant-caps: small-caps;
+          }
+
+          &:first-of-type:first-letter {
+            float: none  !important;
+            padding-right: 0  !important;
+            font-family: Georgia, "New Times Roman", serif;
+            font-size: initial  !important;
+            font-variant-caps:normal  !important;
+            line-height: initial  !important;
+            margin-bottom: 0 !important;
+            color: initial !important;
+          }
+
+          &:first-of-type::first-letter {
+            float: none  !important;
+            padding-right: 0  !important;
+            font-family: Georgia, "New Times Roman", serif;
+            font-size: initial !important;
+            font-variant-caps:normal !important;
+            line-height: initial !important;
+            margin-bottom: 0 !important;
+            color: initial !important;
+          }
+
+          &:last-child:after {
+            color: #777;
+            content: "\2766";
+            display: inline;
+            font-family: Georgia, "New Times Roman", serif;
+            font-size: 1.25em;
+            font-style: italic;
+            font-weight: 300;
+            line-height: 0.75;
+          }
+        }
+      }
+    }
+  }
+
+  div.card__padding {
+
+  }
+
+  div.card__action {
+
+
+    a.btn {
+
+    }
+    a {
+      &.btn-default {
+        border: 1px solid black;
+        background-color: white;
+        color: black !important;
+      }
+      &.btn-danger {
+        border: 1px solid red;
+        background-color: #e90000;
+        color: white;
+      }
+    }
+  }
+}
+
+
+
+
 
 div.card-wrapper {
 
@@ -97,7 +256,7 @@ div.card-wrapper {
       div.card__article {
         position: relative;
         background-color: #fff;
-        
+
         h2 {
           font-size: 125%;
           position: relative;
@@ -119,7 +278,8 @@ div.card-wrapper {
 
           }
 
-          span {
+          div {
+            display: inline-block;
 
             a {
               color: #005aa9;
@@ -278,24 +438,24 @@ div.card-wrapper {
             outline: 3px orange dashed;
           }
         }
-        
-        div.share-expanded {
-              outline: 0;
-              &:before {
-                /*content: "\f00d";*/
-                text-decoration: none;
-              }
-              text-decoration: none;
-              &>a img {
-                transition: transform 0.35s ease;
-                -webkit-transform: rotate(-90deg);
-                transform: rotate(-90deg);
-                position: relative;
-              }
-              .icon-black {
 
-              }
-            }
+        div.share-expanded {
+          outline: 0;
+          &:before {
+            /*content: "\f00d";*/
+            text-decoration: none;
+          }
+          text-decoration: none;
+          &>a img {
+            transition: transform 0.35s ease;
+            -webkit-transform: rotate(-90deg);
+            transform: rotate(-90deg);
+            position: relative;
+          }
+          .icon-black {
+
+          }
+        }
 
         div.text {
           flex: 1 0 auto;
@@ -323,11 +483,11 @@ div.card-wrapper {
                 padding: 0.3rem;
               }
             }
-            
+
             &:first-of-type:first-line {
               font-variant-caps: small-caps;
             }
-            
+
             &:first-of-type::first-line {
               font-variant-caps: small-caps;
             }
@@ -342,7 +502,7 @@ div.card-wrapper {
               margin-bottom: 0;
               color: black !important;
             }
-            
+
             &:first-of-type::first-letter {
               float: left;
               padding-right: 0.07em;
@@ -370,7 +530,7 @@ div.card-wrapper {
     }
 
     div.card__padding {
-      
+
     }
 
     div.card__action {
@@ -411,3 +571,11 @@ div.card-wrapper {
     }
   }
 }
+
+
+
+
+
+
+
+


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the Project Github issue tracker

-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Resolve issue/feat. n° <!-- add #theNumberInGithubIssue -->
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] existing message properties have been updated with new phrases
- [x] new (i18n) language set have been added
- [ ] improvement to make view conforms with [WCAG 2.1 AA][]

##### Description of change
Because of lack of support of :host-context() in Safari and Edge, I add a scoped css Class on top of the wrapper div element equal to the document lang page...

it works on Edge 👍 

![image](https://user-images.githubusercontent.com/1481430/49875432-49c7b200-fe21-11e8-8a16-ffb557f42a21.png)


<!-- Reference Links -->

[wcag 2.1 aa]: https://www.w3.org/TR/WCAG21/
