### PR TITLE
a11y + i18n: the label of the social menu is internationalized

### DIFF
--- a/src/my-card.js
+++ b/src/my-card.js
@@ -97,14 +97,17 @@ class myCard extends HTMLElement {
 
     const articleList = shadowroot.querySelector(".card__social");
     const articleToggle = shadowroot.querySelector(".card__share");
+    const toggle = shadowroot.querySelector(".share-toggle");
     articleList.classList.toggle("card__social--active");
     articleToggle.classList.toggle("share-expanded");
 
     if (articleToggle.getAttribute("aria-expanded") === "true") {
       articleToggle.setAttribute("aria-expanded", "false");
+      toggle.setAttribute("aria-label", this.data.toggle.stateClosed);
     } else {
       articleToggle.setAttribute("aria-expanded", "true");
       articleToggle.focus();
+      toggle.setAttribute("aria-label", this.data.toggle.stateOpened);
     }
   }
 
@@ -179,7 +182,9 @@ class myCard extends HTMLElement {
     }" aria-label="${
       data.linkMenu1.label
     }" target="_blank" rel="noopener noreferrer"><img src="${baseSvg +
-      data.linkMenu1.glyphicon}" class="${data.linkMenu1.iconColor}" alt=""></a>
+      data.linkMenu1.glyphicon}" class="${
+      data.linkMenu1.iconColor
+    }" aria-hidden="true" alt=""></a>
             <a role="menuitem" id="${data.linkMenu2.id}" tabindex="0" class="${
       data.linkMenu2.cssClass
     }" href="${data.linkMenu2.link}" title="${
@@ -187,7 +192,9 @@ class myCard extends HTMLElement {
     }" aria-label="${
       data.linkMenu2.label
     }" target="_blank" rel="noopener noreferrer"><img src="${baseSvg +
-      data.linkMenu2.glyphicon}" class="${data.linkMenu2.iconColor}" alt=""></a>
+      data.linkMenu2.glyphicon}" class="${
+      data.linkMenu2.iconColor
+    }" aria-hidden="true" alt=""></a>
             <a role="menuitem" id="${data.linkMenu3.id}" tabindex="0" class="${
       data.linkMenu3.cssClass
     }" href="${data.linkMenu3.link}" title="${
@@ -195,10 +202,14 @@ class myCard extends HTMLElement {
     }" aria-label="${
       data.linkMenu3.label
     }" target="_blank" rel="noopener noreferrer"><img src="${baseSvg +
-      data.linkMenu3.glyphicon}" class="${data.linkMenu3.iconColor}" alt=""></a>
+      data.linkMenu3.glyphicon}" class="${
+      data.linkMenu3.iconColor
+    }" aria-hidden="true" alt=""></a>
           </div>
-          <a class="share-toggle share-icon"  onclick="${onclick}" href="javascript:void(0);" aria-controls="what-is-uportal-i18n-list" aria-haspopup="true" aria-label="Menu"><img src="${baseSvg +
-      "solid/ellipsis-v.svg"}" class="icon-black" alt=""></i></a>
+          <a class="share-toggle share-icon"  onclick="${onclick}" href="javascript:void(0);" aria-controls="what-is-uportal-i18n-list" aria-haspopup="true" aria-label="${
+      data.toggle.stateClosed
+    }"><img src="${baseSvg +
+      "solid/ellipsis-v.svg"}" class="icon-black" aria-hidden="true" alt=""></i></a>
 
 
         </div>

--- a/static/i18n/ar/messages.json
+++ b/static/i18n/ar/messages.json
@@ -2,6 +2,10 @@
   "imgsrc": "https://cousquer.github.io/apereo2017/assets/artworks/apereo-uportal.jpg",
   "title": "ما هو uPortal؟",
   "time": "13 يونيو 2018",
+  "toggle": {
+    "stateClosed": "فتح القائمة على اليسار",
+    "stateOpened": "أغلق القائمة"
+  },
   "linkMenu1": {
     "id": "museum-menu-item-1",
     "cssClass": "share-icon lightblue",

--- a/static/i18n/en-US/messages.json
+++ b/static/i18n/en-US/messages.json
@@ -2,6 +2,10 @@
   "imgsrc": "https://cousquer.github.io/apereo2017/assets/artworks/apereo-uportal.jpg",
   "title": "What is uPortal?",
   "time": "June 13, 2018",
+  "toggle": {
+    "stateClosed": "Expand the menu on the left",
+    "stateOpened": "Collapse the menu"
+  },
   "linkMenu1": {
     "id": "museum-menu-item-1",
     "cssClass": "share-icon lightblue",

--- a/static/i18n/es-ES/messages.json
+++ b/static/i18n/es-ES/messages.json
@@ -2,6 +2,10 @@
   "imgsrc": "https://cousquer.github.io/apereo2017/assets/artworks/apereo-uportal.jpg",
   "title": "¿Qué es uPortal?",
   "time": "13 de junio de 2018",
+  "toggle": {
+    "stateClosed": "Abrir el menu a la izquierda",
+    "stateOpened": "Cierra el menu"
+  },
   "linkMenu1": {
     "id": "museum-menu-item-1",
     "cssClass": "share-icon lightblue",

--- a/static/i18n/fr-FR/messages.json
+++ b/static/i18n/fr-FR/messages.json
@@ -2,6 +2,10 @@
   "imgsrc": "https://cousquer.github.io/apereo2017/assets/artworks/apereo-uportal.jpg",
   "title": "Qu'est-ce que uPortal ?",
   "time": "13 Juin 2018",
+  "toggle": {
+    "stateClosed": "Ouvrir le menu sur sa gauche",
+    "stateOpened": "Fermer le menu"
+  },
   "linkMenu1": {
     "id": "museum-menu-item-1",
     "cssClass": "share-icon lightblue",

--- a/static/i18n/it/messages.json
+++ b/static/i18n/it/messages.json
@@ -2,6 +2,10 @@
   "imgsrc": "https://cousquer.github.io/apereo2017/assets/artworks/apereo-uportal.jpg",
   "title": "Cos'è uPortal?",
   "time": "13 giugno 2018",
+  "toggle": {
+    "stateClosed": "Apri il menu a sinistra",
+    "stateOpened": "Chiudi il menu"
+  },
   "linkMenu1": {
     "id": "museum-menu-item-1",
     "cssClass": "share-icon lightblue",

--- a/static/i18n/nl-NL/messages.json
+++ b/static/i18n/nl-NL/messages.json
@@ -2,6 +2,10 @@
   "imgsrc": "https://cousquer.github.io/apereo2017/assets/artworks/apereo-uportal.jpg",
   "title": "Wat is uPortal?",
   "time": "13 Juni 2018",
+  "toggle": {
+    "stateClosed": "Open het menu aan de linkerkant",
+    "stateOpened": "Sluit het menu"
+  },
   "linkMenu1": {
     "id": "museum-menu-item-1",
     "cssClass": "share-icon lightblue",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the Project Github issue tracker

-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Resolve issue/feat. n° #61  <!-- add #theNumberInGithubIssue -->
- [ ] tests are included
- [ ] documentation is changed or added
- [x] existing message properties have been updated with new phrases
- [ ] new (i18n) language set have been added
- [x] improvement to make view conforms with [WCAG 2.1 AA][]

##### Description of change
**i18n**
The value of the aria-label attribute of the toggle menu is now coming from messages.json.
**a11y**
No need now to indicate a whatever changing of language on the toggle because of the hard-coded value... the label of the link is now appropriate in every language.
**WCAG2.1**
- [1.1.1#non-text-content](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=111#non-text-content) A
- [2.4.4#link-purpose-in-context](https://www.w3.org/WAI/WCAG21/quickref/#link-purpose-in-context) A
- [2.4.9#link-purpose-link-only](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244#link-purpose-link-only) AAA
- [3.1.2#language-of-parts](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244%2C249#language-of-parts) AA
- [3.2.2#on-input](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=244%2C249#on-input) AA _the user is warned the menu will open on its left..._

<!-- Reference Links -->

[wcag 2.1 aa]: https://www.w3.org/TR/WCAG21/
