### PR TITLE
style: smooth start of transition with opacity shift

### DIFF
--- a/static/scss/my-card.scss
+++ b/static/scss/my-card.scss
@@ -314,7 +314,8 @@ a:focus-visible {
             top: 0;
             transform: translateZ(0);
             transform: translateX(0px);
-            transition: transform 0.35s ease 0s;
+            transition: transform 0.35s, opacity 0.35s;
+            opacity: 0;
             visibility: hidden;
             width: 240px;
 
@@ -396,19 +397,18 @@ a:focus-visible {
               &.white:active {
                 color: #000 !important;
               }
-            }
 
-            a:focus-visible {
-              outline: 3px orange dashed;
+              &:focus-visible {
+                outline: 3px orange dashed;
+              }
             }
           }
 
-          div.card__social--active {
+          .card__social--active {
             visibility: visible;
-            /*z-index: 3;*/
+            opacity: 1;
             transform: translateZ(0);
             transform: translateX(-48px);
-            transition: transform 0.35s ease;
           }
 
           a.share-toggle {
@@ -465,7 +465,6 @@ a:focus-visible {
           text-decoration: none;
 
           &:before {
-            /*content: "\f00d";*/
             text-decoration: none;
           }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the Project Github issue tracker

-->

##### Description of change

This is an attempt to smooth out the appearance of the elements at the start of the social icons animation.

Before:
![before](https://user-images.githubusercontent.com/3107513/50023020-3b9da100-ff9b-11e8-8873-7f908568d818.gif)

---

After:
![after](https://user-images.githubusercontent.com/3107513/50023032-40faeb80-ff9b-11e8-9730-67d904731c87.gif)

---

An alternative could be to shift icons so first icon appears to start from inside the floating action button (FAB), then individually change visibility of icon so they also appear to be coming from the FAB. See: https://codepen.io/kylelavery88/pen/KdmBOe

[wcag 2.1 aa]: https://www.w3.org/TR/WCAG21/
