### PR TITLE
style: avoid animated reflow, normalize padding

### DIFF
--- a/static/scss/my-card.scss
+++ b/static/scss/my-card.scss
@@ -541,10 +541,10 @@ a:focus-visible {
 
       a {
         &.btn {
-          padding: 0.75rem;
+          padding: 0.75rem 0.75rem 1rem;
           border: 1px solid red;
           text-decoration: none;
-          transition: all 0.5s ease;
+          transition: box-shadow 0.5s;
           color: white;
           border-radius: 2px;
           display: inline-block;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the Project Github issue tracker

-->

##### Description of change

The resolves two minor visual quirks.

1. During load on Chrome the content reflow gets picked up by the transition property, animating the button size.

Before:

![refresh-before](https://user-images.githubusercontent.com/3107513/50024084-7ce38000-ff9e-11e8-8976-8a20f3e2556a.gif)

This update ensures only the border is transitioned.

After:

![after-refresh](https://user-images.githubusercontent.com/3107513/50024109-91c01380-ff9e-11e8-9a02-b9bd486d47cd.gif)

2. The button padding is even from a numeric perspective, but is slightly smaller below the text than above when the text and icon are factored in.

Before:
![selection_005](https://user-images.githubusercontent.com/3107513/50024271-08f5a780-ff9f-11e8-944d-edaa7828f307.png)

After:
![selection_006](https://user-images.githubusercontent.com/3107513/50024276-0dba5b80-ff9f-11e8-88e8-ce89441ac34a.png)

[wcag 2.1 aa]: https://www.w3.org/TR/WCAG21/
